### PR TITLE
Send metrics to Datadog when client side QOS test fails to start

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=io.split
-version=22.9.2
+version=22.9.3

--- a/src/main/java/io/split/qos/server/integrations/datadog/DatadogBroadcaster.java
+++ b/src/main/java/io/split/qos/server/integrations/datadog/DatadogBroadcaster.java
@@ -40,4 +40,10 @@ public interface DatadogBroadcaster extends AutoCloseable, Integration {
      */
     void success(Description description, String serverName, Long duration, Optional<String> titleLink);
 
+    /**
+     * Broadcasts the sauce labs failure
+     *
+     * @param description the test description.
+     */
+    void sauceFailure(Description description, String serverName);
 }

--- a/src/main/java/io/split/qos/server/integrations/datadog/DatadogBroadcasterImpl.java
+++ b/src/main/java/io/split/qos/server/integrations/datadog/DatadogBroadcasterImpl.java
@@ -73,6 +73,12 @@ public class DatadogBroadcasterImpl implements DatadogBroadcaster {
         reportServerState();
     }
 
+    @Override
+    public void sauceFailure(Description description, String serverName) {
+        String[] tags = Lists.newArrayList("servername:" + serverName, "testname:" + description.getMethodName()).toArray(new String[3]);
+        this.statsDClient.count("test.saucefail", 1,tags);
+    }
+
     private void reportServerState() {
         String[] tags = Lists.newArrayList("servername:"+ this.qosServerName).toArray(new String[1]);
         this.statsDClient.gauge("all.succeededTests", serverState.succeededTests().size(), tags);

--- a/src/main/java/io/split/qos/server/util/BroadcasterTestWatcher.java
+++ b/src/main/java/io/split/qos/server/util/BroadcasterTestWatcher.java
@@ -134,6 +134,11 @@ public class BroadcasterTestWatcher extends TestWatcher {
                 if (Broadcast.REBROADCAST.equals(broadcast)) {
                     datadog.reBroadcastFailure(description, e, serverName, failCondition.firstFailure(testId), length, titleLink);
                 }
+                // Send to Datadog every time it fails due to Sauce Labs
+                String reason = e.getMessage();
+                if (reason.contains("Could not start a new session.") || reason.contains("It is impossible to create a new session")) {
+                    datadog.sauceFailure(description, serverName);
+                }
             }
         }
     }


### PR DESCRIPTION
Filtering by the reason of failure we can get the tests that run on Sauce Labs, and send metrics to Datadog