### PR TITLE
Comment custom metric qos.test.success

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=io.split
-version=22.9.10
+version=22.9.11

--- a/src/main/java/io/split/qos/server/integrations/datadog/DatadogBroadcasterImpl.java
+++ b/src/main/java/io/split/qos/server/integrations/datadog/DatadogBroadcasterImpl.java
@@ -68,8 +68,9 @@ public class DatadogBroadcasterImpl implements DatadogBroadcaster {
 
     @Override
     public void success(Description description, String serverName, Long duration, Optional<String> titleLink) {
-        String[] tags = Lists.newArrayList("servername:" + serverName, "length:" + durationToSeconds(duration), "testname:" + description.getMethodName()).toArray(new String[3]);
-        this.statsDClient.count("test.success", 1, tags);
+        // disable 'qos.test.success' custom metric
+//        String[] tags = Lists.newArrayList("servername:" + serverName, "length:" + durationToSeconds(duration), "testname:" + description.getMethodName()).toArray(new String[3]);
+//        this.statsDClient.count("test.success", 1, tags);
         reportServerState();
     }
 


### PR DESCRIPTION
Comment custom metric `qos.test.success` to save some money in Datadog Stage.
This change should not affect other metrics. 
[Document](https://splitio.atlassian.net/wiki/spaces/EN/pages/2494595460/Datadog+Custom+Metrics+from+QOS)