### PR TITLE
Add testAborted method for sauce labs fails

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=io.split
-version=22.9.12
+version=22.9.13

--- a/releases.txt
+++ b/releases.txt
@@ -1,4 +1,7 @@
 VERSION COMMENT
 
+v22.9.12 - Add testAborted() method for tests that fail due to Sauce Labs VMs unavailability
+v22.9.11 - Add GET_TREATMENTS_BY_FLAG_SET and GET_TREATMENTS_BY_FLAG_SETS properties
+
 v22.9.2 - LIVE_TAIL_URL, CALL_HOME_URL & CALL_HOME_AUTH added to QOSPropertiesModule
 v22.9.1 - Common Properties added to QOSPropertiesModule and ShadowJAR implemented

--- a/src/main/java/io/split/qos/server/QOSServerBehaviour.java
+++ b/src/main/java/io/split/qos/server/QOSServerBehaviour.java
@@ -105,7 +105,7 @@ public class QOSServerBehaviour implements Callable<Void>, AutoCloseable {
      *     <li> Do all the initialization</li>
      *     <li> Find all the classes that are annotated with the suite, then find all the tests of those classes</li>
      *     <li> Add each test to an executor. The tests will be spread if spreadTests is enabled</li>
-     *     <li> When each tests finished, it will be readded to the executor, with some delay specificed in delayBetweenInSeconds</li>
+     *     <li> When each tests finished, it will be read to the executor, with some delay specified in delayBetweenInSeconds</li>
      * </ul>
      */
     @Override
@@ -113,7 +113,7 @@ public class QOSServerBehaviour implements Callable<Void>, AutoCloseable {
         LOG.info(String.format("STARTING QOS Server for suites %s, running %s tests in parallel", suites, parallelTests));
 
         List<Method> sheduled = scheduleTests();
-        String message = String.format("[%s] QOS Server '%s' is up", serverName,serverName);
+        String message = String.format("*[%s] QOS Server is up*", serverName);
         if (sheduled.size() == 0) {
             LOG.error("Could not find tests to run on " + suites + " package " + suitesPackage);
             message = String.format("No tests found for %s, suites %s, package %s", serverName, suites, suitesPackage);

--- a/src/main/java/io/split/qos/server/QOSServerState.java
+++ b/src/main/java/io/split/qos/server/QOSServerState.java
@@ -114,6 +114,15 @@ public class QOSServerState {
         this.lastGreen = null;
     }
 
+    public void testAborted(Description description) {
+        testAborted(TestId.fromDescription(description));
+    }
+
+    // Get the test back to the running queue when aborted
+    public void testAborted(TestId testId) {
+        this.tests.put(testId, TestStatus.empty());
+    }
+
     public enum Status {
         ACTIVE,
         PAUSED,

--- a/src/main/java/io/split/qos/server/util/BroadcasterTestWatcher.java
+++ b/src/main/java/io/split/qos/server/util/BroadcasterTestWatcher.java
@@ -102,11 +102,21 @@ public class BroadcasterTestWatcher extends TestWatcher {
                 length = System.currentTimeMillis() - started.get(testId);
             }
 
+            // Tests that run on Sauce Labs have limited amount of VMs to run
+            // Test could fail due to a promised VM that is already in use when get the session
+            // Those tests will be treated as aborted, and will be back to the running queue
+            String reason = e.getMessage();
+            Boolean testAborted = false;
+            if (reason.contains("Could not start a new session.") || reason.contains("It is impossible to create a new session")) {
+                state.testAborted(description);
+                testAborted = true;
+            }
+
             // Slack
             Broadcast broadcast = failCondition.failed(testId);
             SlackTestResultBroadcaster resultBroadcaster = QOSServerApplication.injector.getInstance(SlackTestResultBroadcaster.class);
             if (resultBroadcaster.isEnabled()) {
-                if (Broadcast.FIRST.equals(broadcast)) {
+                if (Broadcast.FIRST.equals(broadcast) || testAborted) {
                     state.testFailed(description);
                     resultBroadcaster.firstFailure(description, e, serverName, length, titleLink);
                 }
@@ -130,14 +140,14 @@ public class BroadcasterTestWatcher extends TestWatcher {
             // Datadog
             DatadogBroadcaster datadog = QOSServerApplication.injector.getInstance(DatadogBroadcaster.class);
             if (resultBroadcaster.isEnabled()) {
-                if (Broadcast.FIRST.equals(broadcast)) {
+                if (Broadcast.FIRST.equals(broadcast) || testAborted) {
                     datadog.firstFailure(description, e, serverName, length, titleLink);
                 }
                 if (Broadcast.REBROADCAST.equals(broadcast)) {
                     datadog.reBroadcastFailure(description, e, serverName, failCondition.firstFailure(testId), length, titleLink);
                 }
                 // Send to Datadog every time it fails due to Sauce Labs
-                String reason = e.getMessage();
+                reason = e.getMessage();
                 if (reason.contains("Could not start a new session.") || reason.contains("It is impossible to create a new session")) {
                     LOG.info(String.format("Sauce error: The test %s failed with reason: %s", description.getMethodName(), reason));
                     datadog.sauceFailure(description, serverName);


### PR DESCRIPTION
Tests that fail due to Sauce Labs VM unavailability will be introduced into the running queue again.
They still will report to Datadog as failing and broadcast to Slack for the record