### PR TITLE
Separate aborted tests workflow

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=io.split
-version=22.9.13
+version=22.9.14


### PR DESCRIPTION
Tests that fail because of Sauce Labs will report to Slack and DD, but will not be marked as failed in the Failed Tests list