### PR TITLE
Return test to the queue when vm manager fails

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=io.split
-version=22.9.19
+version=22.9.20

--- a/releases.txt
+++ b/releases.txt
@@ -1,5 +1,6 @@
 VERSION COMMENT
 
+v22.9.20 - Tests that fail due to VM Manager will go back to the queue, instead of be marked as failed
 v22.9.19 - Add SAUCE_USER property to QOSPropertiesModule
 v22.9.18 - Add VM_MANAGER_URL to QOSPropertiesModule
 v22.9.17 - Fix error report when a test fails to connect to Sauce Labs

--- a/src/main/java/io/split/qos/server/util/BroadcasterTestWatcher.java
+++ b/src/main/java/io/split/qos/server/util/BroadcasterTestWatcher.java
@@ -37,6 +37,10 @@ public class BroadcasterTestWatcher extends TestWatcher {
     //Hack to set the title link at runtime
     private Optional<String> titleLink;
 
+    public static String noStartNewSession = "Could not start a new session.";
+    public static String noCreateNewSession = "Could not create a new session.";
+    public static String noVMManager = "Error requesting VM from VM-MANAGER";
+
     @Inject
     public BroadcasterTestWatcher(
             FailCondition failCondition,
@@ -111,14 +115,16 @@ public class BroadcasterTestWatcher extends TestWatcher {
             // Tests that run on Sauce Labs have limited amount of VMs to run
             // Test could fail due to a promised VM that is already in use when get the session
             // Those tests will be treated as aborted, and will be back to the running queue
-            if (reason.contains("Could not start a new session.") || reason.contains("Could not create a new session.")) {
+            if (reason.contains(noStartNewSession) || reason.contains(noCreateNewSession) || reason.contains(noVMManager)) {
                 state.testAborted(description);
                 LOG.info(String.format("Sauce error: The test %s failed with reason: %s", description.getMethodName(), reason));
                 // send message to slack
                 resultBroadcaster.firstFailure(description, e, serverName, length, titleLink);
                 // report to Datadog
                 datadog.firstFailure(description, e, serverName, length, titleLink);
-                datadog.sauceFailure(description, serverName);
+                if (!reason.contains(noVMManager)){
+                    datadog.sauceFailure(description, serverName);
+                }
                 return;
             }
 


### PR DESCRIPTION
The tests that fail because the request to the VM Manager failed, will not be marked as Failed.
And they will not report a failure to Datadog for Sauce Labs error. 
TODO: Add metric to count vm manager failed tests.
