### PR TITLE
Schedule test after 1 sec. Remove duplicated props

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=io.split
-version=22.9.20
+version=22.9.21

--- a/releases.txt
+++ b/releases.txt
@@ -1,5 +1,6 @@
 VERSION COMMENT
 
+v22.9.21 - Schedule tests to start after 1 second after registered
 v22.9.20 - Tests that fail due to VM Manager will go back to the queue, instead of be marked as failed
 v22.9.19 - Add SAUCE_USER property to QOSPropertiesModule
 v22.9.18 - Add VM_MANAGER_URL to QOSPropertiesModule

--- a/src/main/java/io/split/qos/server/QOSServerBehaviour.java
+++ b/src/main/java/io/split/qos/server/QOSServerBehaviour.java
@@ -129,6 +129,9 @@ public class QOSServerBehaviour implements Callable<Void>, AutoCloseable {
         List<Method> methodsToTest = testFinder.getTestMethodsOfPackage(suites, suitesPackage);
         int total = methodsToTest.size();
         int schedule = 0;
+        if (parallelTests > 1){
+            schedule = 1;
+        }
         if (total == 0) {
             return Lists.newArrayList();
         }
@@ -153,7 +156,7 @@ public class QOSServerBehaviour implements Callable<Void>, AutoCloseable {
                     executor);
             schedule += step;
         }
-        return  methodsToTest;
+        return methodsToTest;
     }
 
     public void pause(String who) {
@@ -169,7 +172,7 @@ public class QOSServerBehaviour implements Callable<Void>, AutoCloseable {
     private FutureCallback<TestResult> createCallback(Method method, int when, int ifFailed, int afterFirst) {
         return new FutureCallback<TestResult>() {
             /**
-             * This is where tests are readded to the executor.
+             * This is where tests are read to the executor.
              */
             @Override
             public void onSuccess(TestResult result) {

--- a/src/main/java/io/split/qos/server/QOSServerBehaviour.java
+++ b/src/main/java/io/split/qos/server/QOSServerBehaviour.java
@@ -128,9 +128,9 @@ public class QOSServerBehaviour implements Callable<Void>, AutoCloseable {
     public List<Method> scheduleTests() throws Exception {
         List<Method> methodsToTest = testFinder.getTestMethodsOfPackage(suites, suitesPackage);
         int total = methodsToTest.size();
-        int schedule = 0;
+        int schedule = 1;
         if (parallelTests > 1){
-            schedule = 1;
+            schedule = 2;
         }
         if (total == 0) {
             return Lists.newArrayList();

--- a/src/main/java/io/split/qos/server/modules/QOSPropertiesModule.java
+++ b/src/main/java/io/split/qos/server/modules/QOSPropertiesModule.java
@@ -144,9 +144,6 @@ public class QOSPropertiesModule extends AbstractModule {
         defaultProperties.put(CHECK_MACHINE_NAME_IMPRESSIONS, "false");
         defaultProperties.put(CHECK_SDK_IMPRESSIONS, "false");
         defaultProperties.put(CONFIG_URL, "config");
-        defaultProperties.put(DELAY_BETWEEN_IN_SECONDS, "90");
-        defaultProperties.put(DELAY_BETWEEN_IN_SECONDS_WHEN_FAIL, "500");
-        defaultProperties.put(DESCRIPTION, "-");
         defaultProperties.put(ENVIRONMENT_NAME, "");
         defaultProperties.put(EXPECT_IMPRESSIONS, "false");
         defaultProperties.put(EXPECT_LISTENER_IMPRESSIONS, "false");
@@ -156,19 +153,13 @@ public class QOSPropertiesModule extends AbstractModule {
         defaultProperties.put(GET_TREATMENTS_URL, "gettreatments");
         defaultProperties.put(IMPRESSIONS_URL, "impressions");
         defaultProperties.put(LIVE_TAIL_URL, "");
-        defaultProperties.put(ONE_RUN, "false");
         defaultProperties.put(ORG_ID, "");
-        defaultProperties.put(PARALLEL_TESTS, "10");
         defaultProperties.put(SAUCE_USER, "");
         defaultProperties.put(SDK, "JAVA");
         defaultProperties.put(SDK_API_URL, "");
-        defaultProperties.put(SHUTDOWN_WAIT_IN_MINUTES, "10");
-        defaultProperties.put(SPREAD_TESTS, "true");
         defaultProperties.put(SPLITNAMES_URL, "manager/splitnames");
         defaultProperties.put(SPLIT_URL, "manager/split");
         defaultProperties.put(SPLITS_URL, "manager/splits");
-        defaultProperties.put(SUITES, "SMOKE");
-        defaultProperties.put(SUITES_PACKAGE, "io.split");
         defaultProperties.put(TRAFFIC_NAME, "");
         defaultProperties.put(TREATMENT_CONFIG_URL, "gettreatmentwithconfig");
         defaultProperties.put(TREATMENT_URL, "automation");
@@ -183,16 +174,16 @@ public class QOSPropertiesModule extends AbstractModule {
         defaultProperties.put(WEB_API_URL, "");
 
         // Server
-        defaultProperties.put("PARALLEL_TESTS", "10");
-        defaultProperties.put("SHUTDOWN_WAIT_IN_MINUTES", "10");
-        defaultProperties.put("DELAY_BETWEEN_IN_SECONDS", "300");
-        defaultProperties.put("DELAY_BETWEEN_IN_SECONDS_WHEN_FAIL", "60");
-        defaultProperties.put("SPREAD_TESTS", "true");
-        defaultProperties.put("ONE_RUN", "false");
-        defaultProperties.put("DESCRIPTION", "-");
-        defaultProperties.put("SUITES", "SMOKE");
-        defaultProperties.put("SUITES_PACKAGE", "io.split");
-        defaultProperties.put("TIME_ZONE", "UTC");
+        defaultProperties.put(DELAY_BETWEEN_IN_SECONDS, "300");
+        defaultProperties.put(DELAY_BETWEEN_IN_SECONDS_WHEN_FAIL, "60");
+        defaultProperties.put(DESCRIPTION, "-");
+        defaultProperties.put(ONE_RUN, "false");
+        defaultProperties.put(PARALLEL_TESTS, "10");
+        defaultProperties.put(SHUTDOWN_WAIT_IN_MINUTES, "10");
+        defaultProperties.put(SPREAD_TESTS, "true");
+        defaultProperties.put(SUITES, "SMOKE");
+        defaultProperties.put(SUITES_PACKAGE, "io.split");
+        defaultProperties.put(TIME_ZONE, "UTC");
 
         // Test
         defaultProperties.put(RE_BROADCAST_FAILURE_IN_MINUTES, "60");


### PR DESCRIPTION
Schedule tests to start after 1 second from registered, this should give time to the vm manager to get the requests for sauce labs tests.
Remove duplicated properties configuration